### PR TITLE
fix spelling

### DIFF
--- a/lib/Template/Plugin/Gettext.pod
+++ b/lib/Template/Plugin/Gettext.pod
@@ -321,7 +321,7 @@ instead, so that you can interpolate the value of B<COUNT>!
 
 =item B<[% debug_locale %]>
 
-The plug-in implicitely calls B<web_set_locale()> (see
+The plug-in implicitly calls B<web_set_locale()> (see
 L<Locale::Util>) if a language was specified in the B<USE> 
 statement.  The function B<debug_locale()> gives you the return
 value of the call for debugging purposes.  Example:


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Template-Plugin-Gettext.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtemplate-plugin-gettext-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
