### PR TITLE
fix pod warnings

### DIFF
--- a/bin/xgettext-tt2
+++ b/bin/xgettext-tt2
@@ -30,9 +30,7 @@ my %options;
 
 Locale::XGettext::TT2->newFromArgv(\@ARGV)->run->output;
 
-=head1 xgettext-tt2
-
-Extract translatable strings from Template Toolkit 2 templates
+=head1 NAME xgettext-tt2 - Extract translatable strings from Template Toolkit 2 templates
 
 =head1 SYNOPSIS
 

--- a/lib/Locale/XGettext/TT2.pod
+++ b/lib/Locale/XGettext/TT2.pod
@@ -1,4 +1,4 @@
-=head1 Locale::XGettext::TT2
+=head1 NAME Locale::XGettext::TT2
 
 Extract translatable strings from template files for the
 Template Toolkit version 2.


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Template-Plugin-Gettext.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtemplate-plugin-gettext-perl/raw/master/debian/patches/fix-pod.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
